### PR TITLE
Update osw_format.py

### DIFF
--- a/src/models/osw_ondemand_request.py
+++ b/src/models/osw_ondemand_request.py
@@ -9,6 +9,9 @@ class RequestData:
     jobId: str
     source: str
     target: str
+    # Type of job id is string
+    def __post_init__(self):
+        self.jobId = str(self.jobId)
 
 
 @dataclass

--- a/src/osw_format.py
+++ b/src/osw_format.py
@@ -52,10 +52,10 @@ class OSWFormat:
             except Exception as err:
                 traceback.print_exc()
                 logger.error(f' Error While Formatting File: {str(err)}')
-                return None
+                raise err
         else:
             logger.error(f' Failed to format because unknown file format')
-            return None
+            raise Exception('Unknown file format')
 
     def download_single_file(self, file_upload_path=None) -> str:
 

--- a/src/service/osw_formatter_service.py
+++ b/src/service/osw_formatter_service.py
@@ -183,51 +183,55 @@ class OSWFomatterService:
         logger.info(f"Publishing message for : {upload_message.message_id}")
 
     def process_on_demand_format(self, request: OSWOnDemandRequest):
-        logger.info("Received on demand request")
-        logger.info(request.data.jobId)
-        logger.info(request.data.sourceUrl)
-        logger.info(request.data.source)
-        logger.info(request.data.target)
-        # Format the file
-        formatter = OSWFormat(
-            file_path=request.data.sourceUrl,
-            storage_client=self.storage_client,
-            prefix=request.data.jobId
-        )
-        result = formatter.format()
-        formatter_result = ValidationResult()
-        osw_response = asdict(request.data)
-        # Create remote path
-        if result and result.status and result.error is None and result.generated_files is not None:
-            logger.info('Formatting complete')
-            if isinstance(result.generated_files, list): # If its a list
-                converted_file = formatter.create_zip(result.generated_files)
+        try:
+            logger.info("Received on demand request")
+            logger.info(request.data.jobId)
+            logger.info(request.data.sourceUrl)
+            logger.info(request.data.source)
+            logger.info(request.data.target)
+            # Format the file
+            formatter = OSWFormat(
+                file_path=request.data.sourceUrl,
+                storage_client=self.storage_client,
+                prefix=request.data.jobId
+            )
+            result = formatter.format()
+            formatter_result = ValidationResult()
+            osw_response = asdict(request.data)
+            # Create remote path
+            if result and result.status and result.error is None and result.generated_files is not None:
+                logger.info('Formatting complete')
+                if isinstance(result.generated_files, list): # If its a list
+                    converted_file = formatter.create_zip(result.generated_files)
+                else:
+                    converted_file = result.generated_files
+
+                target_directory = f'jobs/{request.data.jobId}/{request.data.target}'
+                target_file_remote_path = f'{target_directory}/{os.path.basename(converted_file)}'
+
+                new_file_remote_url = self.upload_to_azure_on_demand(remote_path=target_file_remote_path,
+                                                                    local_url=converted_file)
+
+                logger.info(f'File to be uploaded to: {target_file_remote_path}')
+                
+                OSWFormat.clean_up(converted_file)
+
+                osw_response['status'] = 'completed'
+                osw_response['formattedUrl'] = new_file_remote_url
+                osw_response['message'] = 'OK'
+                osw_response['success'] = True
             else:
-                converted_file = result.generated_files
+                osw_response['status'] = 'failed'
+                osw_response['formattedUrl'] = ''
+                osw_response['message'] = result.error
+                osw_response['success'] = False
 
-            target_directory = f'jobs/{request.data.jobId}/{request.data.target}'
-            target_file_remote_path = f'{target_directory}/{os.path.basename(converted_file)}'
+            response = OSWOnDemandResponse(messageId=request.messageId, messageType=request.messageType, data=osw_response)
 
-            new_file_remote_url = self.upload_to_azure_on_demand(remote_path=target_file_remote_path,
-                                                                 local_url=converted_file)
-
-            logger.info(f'File to be uploaded to: {target_file_remote_path}')
-            
-            OSWFormat.clean_up(converted_file)
-
-            osw_response['status'] = 'completed'
-            osw_response['formattedUrl'] = new_file_remote_url
-            osw_response['message'] = 'OK'
-            osw_response['success'] = True
-        else:
-            osw_response['status'] = 'failed'
-            osw_response['formattedUrl'] = ''
-            osw_response['message'] = result.error
-            osw_response['success'] = False
-
-        response = OSWOnDemandResponse(messageId=request.messageId, messageType=request.messageType, data=osw_response)
-
-        self.send_on_demand_response(response= response)
+            self.send_on_demand_response(response= response)
+        except Exception as e:
+            logger.error(f"Error occurred while processing on demand message, {e}")
+            self.send_on_demand_response(response= OSWOnDemandResponse(messageId=request.messageId, messageType=request.messageType, data={'status': 'failed', 'message': str(e), 'success': False}))
 
     def send_on_demand_response(self, response: OSWOnDemandResponse):
         logger.info(f"Sending response for {response.data.jobId}")


### PR DESCRIPTION
Fixes bug 1093
- Instead of returning None, the formatter  raises the exception back to the calling method and then returned to the service.
- jobId is got as integer but formatter expects this as prefix in string format
- Changed the jobId in the RequestData post processing
- Added try catch exception for on demand processing function
- Not able to run the unit tests locally due to numpy issues (possibly due to GDAL upgrade in the dev system)