### PR TITLE
Fixes the numpy isuse 1097

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ coverage==7.2.7
 html_testRunner==1.2.1
 httpx==0.24.1
 osm-osw-reformatter==0.2.2
+numpy==1.26.4

--- a/tests/unit_tests/test_osw_format.py
+++ b/tests/unit_tests/test_osw_format.py
@@ -48,8 +48,8 @@ class TestOSWFormat(unittest.TestCase):
         self.formatter.file_path = file_path
         self.formatter.file_relative_path = f'{SAVED_FILE_PATH}/test_file.txt'
         mock_clean_up.return_value = None
-        result = self.formatter.format()
-        self.assertIsNone(result)
+        with self.assertRaises(Exception):
+            self.formatter.format()
 
     def test_download_single_file(self):
         file_path = f'{SAVED_FILE_PATH}/osw.zip'


### PR DESCRIPTION
Related to Issue 1097  https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1097

Due to recent change in the numpy library, the service fails to start throwing a compatibility error
- Changed the numpy library and downgraded to the earlier release
- Fixed the unit test that fails due to the recent fix that throws an exception rather than sending a None response.