### PR TITLE
Fix OSM→OSW conversion when OSM Way contains consecutive duplicate nodes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ pydantic==1.10.4
 python-ms-core==0.0.25
 uvicorn==0.20.0
 html_testRunner==1.2.1
-osm-osw-reformatter==0.3.3
+osm-osw-reformatter==0.3.4
 numpy==1.26.4
 pyproj~=3.6.1


### PR DESCRIPTION
## Dev Board Ticket

- https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/3286

## Changes

- Fix OSM→OSW conversion when OSM Way contains consecutive duplicate nodes
- Fix OSM→OSW conversion when OSM Way contains consecutive duplicate nodes (bug 3286). Instead of generating an invalid 0 length geometry, the segment is ignored.

## Testing
- TDEI Portal