### PR TITLE
Fix OSM→OSW zone _w_id references missing from nodes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ pydantic==1.10.4
 python-ms-core==0.0.25
 uvicorn==0.20.0
 html_testRunner==1.2.1
-osm-osw-reformatter==0.3.4
+osm-osw-reformatter==0.3.5
 numpy==1.26.4
 pyproj~=3.6.1


### PR DESCRIPTION
## Dev Board Ticket

- https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/3665
- https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/3191

## Changes

- requirements.txt

## Testing
- TDEI Portal