### PR TITLE
Upgrade `osm-osw-reformatter` to 0.4.0 and remove warnings field

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,7 @@ Follow the steps to install the python packages required for both building and r
       "source_url": "file_upload_path",
       "formatted_url": "uploaded_url",
       "success": true/false,
-      "message": "message",
-      "warnings": ""
+      "message": "message"
     },
   "publishedDate": "published date"
   }
@@ -164,8 +163,7 @@ Follow the steps to install the python packages required for both building and r
     "target": "osm",
     "formattedUrl": "https://tdeisamplestorage.blob.core.windows.net/osw/2023/11/c552d5d1-0719-4647-b86d-6ae9b25327b7/aff14a0d29ab4acbaef639063462e85b/naresh-som-2.zip",
     "success": true,
-    "message": "",
-    "warnings": ""
+    "message": ""
   }
 }
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ pydantic==1.10.4
 python-ms-core==0.0.26
 uvicorn==0.20.0
 html_testRunner==1.2.1
-osm-osw-reformatter==0.3.7
+osm-osw-reformatter==0.4.0
 numpy==1.26.4
 pyproj~=3.6.1

--- a/src/assets/osw-validation-output.json
+++ b/src/assets/osw-validation-output.json
@@ -7,7 +7,6 @@
     "source_url": "https://tdeisamplestorage.blob.core.windows.net/osw/test_upload/osw.zip",
     "formatted_url": "https://tdeisamplestorage.blob.core.windows.net/osw/test_upload/osw.zip",
     "success": true,
-    "message": "",
-    "warnings": ""
+    "message": ""
   }
 }

--- a/src/models/osw_ondemand_response.py
+++ b/src/models/osw_ondemand_response.py
@@ -14,7 +14,6 @@ class ResponseData:
     formattedUrl: Optional[str] = ''
     success: bool = False
     message: str = ''
-    warnings: str = ''
 
 
 @dataclass

--- a/src/models/osw_validation_data.py
+++ b/src/models/osw_validation_data.py
@@ -10,7 +10,6 @@ class OSWValidationData:
         self._formatted_url = data.get('formatted_url', None)
         self._success = data.get('success', False)
         self._message = data.get('message', '')
-        self._warnings = data.get('warnings', '')
 
     @property
     def tdei_project_group_id(self): return self._tdei_project_group_id
@@ -41,12 +40,6 @@ class OSWValidationData:
 
     @message.setter
     def message(self, value): self._message = value
-
-    @property
-    def warnings(self): return self._warnings
-
-    @warnings.setter
-    def warnings(self, value): self._warnings = value or ''
 
     def to_json(self):
         return to_json(self.__dict__)

--- a/src/models/queue_message_content.py
+++ b/src/models/queue_message_content.py
@@ -4,12 +4,10 @@ import json
 class ValidationResult:
     is_valid: bool
     validation_message: str = ''
-    warnings: str = ''
 
-    def __init__(self, is_valid: bool = False, validation_message: str = '', warnings: str = ''):
+    def __init__(self, is_valid: bool = False, validation_message: str = ''):
         self.is_valid = is_valid
         self.validation_message = validation_message
-        self.warnings = warnings
 
 
 class Request:

--- a/src/service/osw_formatter_service.py
+++ b/src/service/osw_formatter_service.py
@@ -120,7 +120,6 @@ class OSWFomatterService:
                 )
                 result = formatter.format()
                 formatter_result = ValidationResult()
-                formatter_result.warnings = result.warnings
                 if result and result.status and result.error is None and result.generated_files is not None:
                     # Generated files can be .xml or a bunch of geojson
                     converted_file = self._prepare_upload_file(
@@ -155,7 +154,6 @@ class OSWFomatterService:
             result = ValidationResult()
             result.is_valid = False
             result.validation_message = f'Error occurred while formatting OSW request {e}'
-            result.warnings = ''
             self.send_status(result=result, upload_message=received_message)
             traceback.print_exc()
         finally:
@@ -185,7 +183,6 @@ class OSWFomatterService:
     def send_status(self, result: ValidationResult, upload_message: OSWValidationMessage, upload_url=None):
         upload_message.data.success = result.is_valid
         upload_message.data.message = result.validation_message
-        upload_message.data.warnings = result.warnings
         if upload_url:
             upload_message.data.formatted_url = upload_url
 
@@ -222,7 +219,6 @@ class OSWFomatterService:
             )
             result = formatter.format()
             osw_response = asdict(request.data)
-            osw_response['warnings'] = result.warnings
             # Create remote path
             if result and result.status and result.error is None and result.generated_files is not None:
                 logger.info('Formatting complete')
@@ -265,8 +261,7 @@ class OSWFomatterService:
                         'status': 'failed',
                         'message': str(e),
                         'success': False,
-                        'jobId': request.data.jobId,
-                        'warnings': ''
+                        'jobId': request.data.jobId
                     }
                 )
             )

--- a/tests/unit_tests/models/test_osw_ondemand_response.py
+++ b/tests/unit_tests/models/test_osw_ondemand_response.py
@@ -16,8 +16,7 @@ class TestOSWOnDemandResponse(unittest.TestCase):
             'status': 'completed',
             'formattedUrl': 'https://example.com/formatted.zip',
             'success': True,
-            'message': 'Formatting successful',
-            'warnings': 'warning one'
+            'message': 'Formatting successful'
         }
 
         osw_response = OSWOnDemandResponse(messageType=message_type, messageId=message_id, data=data)
@@ -33,7 +32,6 @@ class TestOSWOnDemandResponse(unittest.TestCase):
         self.assertEqual(osw_response.data.formattedUrl, data['formattedUrl'])
         self.assertEqual(osw_response.data.success, data['success'])
         self.assertEqual(osw_response.data.message, data['message'])
-        self.assertEqual(osw_response.data.warnings, data['warnings'])
 
     def test_post_init(self):
         # Test post-init behavior
@@ -54,7 +52,6 @@ class TestOSWOnDemandResponse(unittest.TestCase):
 
         # Ensure data is an instance of ResponseData after __post_init__
         self.assertIsInstance(osw_response.data, ResponseData)
-        self.assertEqual(osw_response.data.warnings, '')
 
     def test_invalid_data_type(self):
         # Test when data is not a dictionary

--- a/tests/unit_tests/models/test_osw_validation_data.py
+++ b/tests/unit_tests/models/test_osw_validation_data.py
@@ -21,14 +21,12 @@ class TestOSWValidationData(unittest.TestCase):
     def test_init(self):
         data = {
             'tdei_project_group_id': 'group_id',
-            'file_upload_path': 'some_url',
-            'warnings': 'warning one'
+            'file_upload_path': 'some_url'
         }
         validation_data = OSWValidationData(data)
 
         self.assertEqual(validation_data.tdei_project_group_id, 'group_id')
         self.assertEqual(validation_data.file_upload_path, 'some_url')
-        self.assertEqual(validation_data.warnings, 'warning one')
 
     def test_tdei_project_group_id(self):
         validation_data = OSWValidationData(self.data)
@@ -39,8 +37,7 @@ class TestOSWValidationData(unittest.TestCase):
     def test_to_json(self):
         data = {
             'tdei_project_group_id': 'group_id',
-            'file_upload_path': 'some_url',
-            'warnings': 'warning one'
+            'file_upload_path': 'some_url'
         }
         validation_data = OSWValidationData(data)
 
@@ -48,11 +45,9 @@ class TestOSWValidationData(unittest.TestCase):
 
         self.assertIn('tdei_project_group_id', json_data)
         self.assertIn('file_upload_path', json_data)
-        self.assertIn('warnings', json_data)
 
         self.assertEqual(json_data['tdei_project_group_id'], 'group_id')
         self.assertEqual(json_data['file_upload_path'], 'some_url')
-        self.assertEqual(json_data['warnings'], 'warning one')
 
     def test_remove_underscore(self):
         underscored_string = '_test_string'

--- a/tests/unit_tests/models/test_queue_message_content.py
+++ b/tests/unit_tests/models/test_queue_message_content.py
@@ -29,18 +29,15 @@ class TestValidationResult(unittest.TestCase):
         result.validation_message = 'Validated'
         self.assertTrue(result.is_valid)
         self.assertEqual(result.validation_message, 'Validated')
-        self.assertEqual(result.warnings, '')
 
     def test_validation_result_keyword_init(self):
         result = ValidationResult(
             is_valid=True,
-            validation_message='Validated',
-            warnings='warning one'
+            validation_message='Validated'
         )
 
         self.assertTrue(result.is_valid)
         self.assertEqual(result.validation_message, 'Validated')
-        self.assertEqual(result.warnings, 'warning one')
 
 class TestRequest(unittest.TestCase):
     def test_request_init(self):

--- a/tests/unit_tests/service/test_osw_formatter_service.py
+++ b/tests/unit_tests/service/test_osw_formatter_service.py
@@ -2,8 +2,8 @@ import os
 import json
 import unittest
 from pathlib import Path
-from typing import Optional
-from dataclasses import dataclass, asdict
+from types import SimpleNamespace
+from dataclasses import asdict
 from unittest.mock import ANY, Mock, MagicMock, patch, call
 from src.service.osw_formatter_service import OSWFomatterService
 from src.osw_format import OSWFormat
@@ -26,14 +26,6 @@ ONDEMAND_REQUEST_DATA = json.loads(ONDEMAND_REQUEST_FILE.read())
 
 SAVED_FILE_PATH = f'{Path.cwd()}/tests/unit_tests/test_files'
 DOWNLOAD_PATH = f'{Path.cwd()}/downloads'
-
-
-@dataclass
-class FormatFixture:
-    status: bool
-    error: Optional[str]
-    generated_files: str
-    warnings: str = ''
 
 
 class TestOSWFomatterService(unittest.TestCase):
@@ -102,7 +94,6 @@ class TestOSWFomatterService(unittest.TestCase):
             status=True,
             error=None,
             generated_files='file1.xml',
-            warnings='warning one',
         )
         mock_osw_instance.create_zip.return_value = 'file1.zip'
         mock_osw_format.return_value = mock_osw_instance
@@ -122,8 +113,6 @@ class TestOSWFomatterService(unittest.TestCase):
         # Assert
         mock_send_status.assert_called_once()
         mock_osw_instance.create_zip.assert_called_once_with(['file1.xml'])
-        result = mock_send_status.call_args[1]['result']
-        self.assertEqual(result.warnings, 'warning one')
 
     @patch.object(OSWFomatterService, 'send_status')
     def test_format_failure(self, mock_send_status):
@@ -132,7 +121,11 @@ class TestOSWFomatterService(unittest.TestCase):
 
         # Mock OSWFormat instance
         with patch.object(OSWFormat, '__init__', return_value=None), \
-                patch.object(OSWFormat, 'format', return_value=Mock(status=True, error=None, generated_files='file1.xml')), \
+                patch.object(OSWFormat, 'format', return_value=SimpleNamespace(
+                    status=True,
+                    error=None,
+                    generated_files='file1.xml',
+                )), \
                 patch.object(OSWFormat, 'create_zip', return_value='file1.zip'):
             self.OSW_format = OSWFormat(file_path=file_path, storage_client=MagicMock())
 
@@ -198,7 +191,6 @@ class TestOSWFomatterService(unittest.TestCase):
         result = ValidationResult()
         result.is_valid = True
         result.validation_message = 'Formatting Successful'
-        result.warnings = 'warning one'
 
         upload_message = OSWValidationMessage(TEST_DATA)
         # Call the send_status method
@@ -207,7 +199,6 @@ class TestOSWFomatterService(unittest.TestCase):
         # Add assertions for the expected behavior
         self.assertEqual(upload_message.data.success, True)
         self.assertEqual(upload_message.data.message, 'Formatting Successful')
-        self.assertEqual(upload_message.data.warnings, 'warning one')
 
     def test_valid_send_status_with_upload_url(self):
         self.formatter.publishing_topic = MagicMock()
@@ -253,7 +244,6 @@ class TestOSWFomatterService(unittest.TestCase):
                 status=True,
                 error=None,
                 generated_files='file1.xml',
-                warnings='warning one',
             )
 
             self.formatter.upload_to_azure_on_demand = MagicMock()
@@ -271,8 +261,6 @@ class TestOSWFomatterService(unittest.TestCase):
 
             mock_format.assert_called_once()
             mock_create_zip.assert_called_once_with(['file1.xml'])
-            response = self.formatter.send_on_demand_response.call_args[1]['response']
-            self.assertEqual(response.data.warnings, 'warning one')
 
     @patch.object(OSWFormat, 'format')
     def test_process_on_demand_format_failure(self, mock_format):


### PR DESCRIPTION
### Summary

- Upgraded `osm-osw-reformatter` from `0.3.7` to `0.4.0`.
- Removed the deprecated `warnings` field from service responses and data models.
- Updated API examples, fixtures, and unit tests accordingly.
- Verified all 73 unit tests pass.