### PR TITLE
Upgrade `osm-osw-reformatter` to 0.4.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ pydantic==1.10.4
 python-ms-core==0.0.26
 uvicorn==0.20.0
 html_testRunner==1.2.1
-osm-osw-reformatter==0.4.1
+osm-osw-reformatter==0.4.2
 numpy==1.26.4
 pyproj~=3.6.1


### PR DESCRIPTION
- Upgraded `osm-osw-reformatter` from `0.4.1` to `0.4.2`.